### PR TITLE
Add completed BKBirthdayField

### DIFF
--- a/BKMoneyKit/BKBirthdayField.h
+++ b/BKMoneyKit/BKBirthdayField.h
@@ -1,0 +1,29 @@
+//
+//  BKBirthdayField.h
+//  BKMoneyKit
+//
+//  Created by Joefrey Kibuule on 3/22/15.
+//  Copyright (c) 2015 Byungkook Jang. All rights reserved.
+//
+
+#import "BKForwardingTextField.h"
+
+@interface BKBirthdayField : BKForwardingTextField
+
+/**
+ * Date components that user typed. Undetermined components would be zero.
+ */
+@property (nonatomic, strong) NSDateComponents      *dateComponents;
+
+/**
+ * Returns if current date in birthday field is leap year. Year not typed yes always returns NO.
+ */
+- (BOOL)isLeapYear;
+
+/**
+ * Checks if current month/day/year is valid date
+ * @note: ALWAYS check if date before using, due to leap year logic and day being typed before year
+ */
+- (BOOL)isValidDate;
+
+@end

--- a/BKMoneyKit/BKBirthdayField.m
+++ b/BKMoneyKit/BKBirthdayField.m
@@ -1,0 +1,242 @@
+//
+//  BKBirthdayField.m
+//  BKMoneyKit
+//
+//  Created by Joefrey Kibuule on 3/22/15.
+//  Copyright (c) 2015 Byungkook Jang. All rights reserved.
+//
+
+#import "BKBirthdayField.h"
+#import "BKMoneyUtils.h"
+
+@interface BKBirthdayField ()
+
+@property (nonatomic, strong) NSRegularExpression *nonNumericRegularExpression;
+@property (nonatomic, strong) NSCharacterSet *numberCharacterSet;
+
+@end
+
+@implementation BKBirthdayField
+
+- (void)commonInit
+{
+    [super commonInit];
+    
+    self.placeholder = @"MM / DD / YYYY";
+    self.keyboardType = UIKeyboardTypeNumberPad;
+    self.clearButtonMode = UITextFieldViewModeAlways;
+    
+    _numberCharacterSet = [BKMoneyUtils numberCharacterSet];
+    _nonNumericRegularExpression = [BKMoneyUtils nonNumericRegularExpression];
+}
+
+- (void)dealloc
+{
+}
+
+- (NSString *)numberOnlyStringWithString:(NSString *)string
+{
+    return [self.nonNumericRegularExpression stringByReplacingMatchesInString:string
+                                                                      options:0
+                                                                        range:NSMakeRange(0, string.length)
+                                                                 withTemplate:@""];
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
+{
+    if ([self.userDelegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
+        if (NO == [self.userDelegate textField:textField shouldChangeCharactersInRange:range replacementString:string]) {
+            return NO;
+        }
+    }
+    
+    NSString *currentText = textField.text;
+    
+    NSCharacterSet *nonNumberCharacterSet = [self.numberCharacterSet invertedSet];
+    
+    if (string.length == 0 && [[currentText substringWithRange:range] stringByTrimmingCharactersInSet:nonNumberCharacterSet].length == 0) {
+        // find non-whitespace character backward
+        NSRange numberCharacterRange = [currentText rangeOfCharacterFromSet:self.numberCharacterSet
+                                                                    options:NSBackwardsSearch
+                                                                      range:NSMakeRange(0, range.location)];
+        // adjust replace range
+        if (numberCharacterRange.location != NSNotFound) {
+            range = NSUnionRange(range, numberCharacterRange);
+        }
+    }
+    
+    NSString *replacedString = [currentText stringByReplacingCharactersInRange:range withString:string];
+    NSString *numberOnlyString = [self numberOnlyStringWithString:replacedString];
+    
+    if (numberOnlyString.length > 8) {
+        return NO;
+    }
+    
+    if (numberOnlyString.length == 1 && [numberOnlyString substringToIndex:1].integerValue > 1) {
+        numberOnlyString = [@"0" stringByAppendingString:numberOnlyString];
+    }
+    
+    NSInteger monthInteger = 0;
+    NSMutableString *formattedString = [NSMutableString string];
+    
+    if (numberOnlyString.length > 0) {
+        NSString *monthString = [numberOnlyString substringToIndex:MIN(2, numberOnlyString.length)];
+        
+        if (monthString.length == 2) {
+            monthInteger = monthString.integerValue;
+            if (monthInteger < 1 || monthInteger > 12) {
+                return NO;
+            }
+        }
+        [formattedString appendString:monthString];
+    }
+    
+    if (numberOnlyString.length > 1) {
+        [formattedString appendString:@" / "];
+    }
+    
+    if ([numberOnlyString length] > 2) {
+        NSInteger numOfDayDigits = numberOnlyString.length > 3 ? 2 : 1;
+        NSString *dayString = [numberOnlyString substringWithRange:NSMakeRange(2, numOfDayDigits)];
+        
+        if (dayString.length == 1) {
+            NSInteger dayInteger = dayString.integerValue;
+            
+            if (dayInteger < 0 || dayInteger > 3) {
+                return NO;
+            }
+        } else if (dayString.length == 2) {
+            NSInteger dayInteger = dayString.integerValue;
+            
+            switch (monthInteger) {
+                case 1:
+                case 3:
+                case 5:
+                case 7:
+                case 8:
+                case 10:
+                case 12:
+                    if (dayInteger < 1 || dayInteger > 31) {
+                        return NO;
+                    }
+                    break;
+                case 4:
+                case 6:
+                case 9:
+                case 11:
+                    if (dayInteger < 1 || dayInteger > 30) {
+                        return NO;
+                    }
+                    break;
+                case 2:
+                    // Month is typed before year, won't know if it's a leap year, bound check against upper limit
+                    if (dayInteger < 1 || dayInteger > 29) {
+                        return NO;
+                    }
+                    break;
+                default:
+                    return NO;
+                    break;
+            }
+        }
+        [formattedString appendString:dayString];
+    }
+    
+    if (numberOnlyString.length > 3) {
+        [formattedString appendString:@" / "];
+    }
+    
+    if (numberOnlyString.length > 4) {
+        NSString *yearString = [numberOnlyString substringFromIndex:4];
+        [formattedString appendString:yearString];
+    }
+    
+    [self setText:formattedString];
+    
+    [self sendActionsForControlEvents:UIControlEventEditingChanged];
+    
+    return NO;
+}
+
+- (NSDateComponents *)dateComponentsWithString:(NSString *)string
+{
+    NSString *numberString = [self numberOnlyStringWithString:string];
+    
+    NSDateComponents *result = [[NSDateComponents alloc] init];
+    result.year = 0;
+    result.month = 0;
+    result.day = 0;
+    
+    if (numberString.length > 1) {
+        result.month = [[numberString substringToIndex:2] integerValue];
+    }
+    
+    if (numberString.length > 2) {
+        NSInteger numOfDayDigits = (numberString.length > 3) ? 2 : 1;
+        result.day = [[numberString substringWithRange:NSMakeRange(2, numOfDayDigits)] integerValue];
+    }
+    
+    if (numberString.length > 4) {
+        result.year = [[numberString substringFromIndex:4] integerValue];
+    }
+    
+    return result;
+}
+
++ (BOOL)isLeapYearForYear:(NSInteger)year {
+    
+    if (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) {
+        return YES;
+    }
+    
+    return NO;
+}
+
+#pragma mark - Public methods
+
+- (NSDateComponents *)dateComponents
+{
+    return [self dateComponentsWithString:self.text];
+}
+
+- (void)setDateComponents:(NSDateComponents *)dateComponents
+{
+    [self setText:[NSString stringWithFormat:@"%02ld / %02ld / %02ld", (long)dateComponents.month, (long)dateComponents.day, (long)dateComponents.year]];
+}
+
+- (BOOL)isLeapYear {
+    NSDateComponents *currentComponents = [self dateComponents];
+    
+    if (currentComponents.year == 0) {
+        return NO;
+    }
+    
+    return [[self class] isLeapYearForYear:currentComponents.year];
+}
+
+- (BOOL)isValidDate {
+    NSDateComponents *currentComponents = [self dateComponents];
+    
+    if (currentComponents.year != 0) {
+        
+        if (currentComponents.month > 0 && currentComponents.month < 13) {
+            
+            if ([[self class] isLeapYearForYear:currentComponents.year]) {
+                
+                if (self.dateComponents.day > 0 && self.dateComponents.day < 30) {
+                    return YES;
+                }
+            } else {
+                if (self.dateComponents.day > 0 && self.dateComponents.day < 29) {
+                    return YES;
+                }
+            }
+        }
+    }
+    
+    return NO;
+}
+
+@end

--- a/BKMoneyKit/BKBirthdayField.m
+++ b/BKMoneyKit/BKBirthdayField.m
@@ -110,35 +110,8 @@
         } else if (dayString.length == 2) {
             NSInteger dayInteger = dayString.integerValue;
             
-            switch (monthInteger) {
-                case 1:
-                case 3:
-                case 5:
-                case 7:
-                case 8:
-                case 10:
-                case 12:
-                    if (dayInteger < 1 || dayInteger > 31) {
-                        return NO;
-                    }
-                    break;
-                case 4:
-                case 6:
-                case 9:
-                case 11:
-                    if (dayInteger < 1 || dayInteger > 30) {
-                        return NO;
-                    }
-                    break;
-                case 2:
-                    // Month is typed before year, won't know if it's a leap year, bound check against upper limit
-                    if (dayInteger < 1 || dayInteger > 29) {
-                        return NO;
-                    }
-                    break;
-                default:
-                    return NO;
-                    break;
+            if (![self isValidDay:dayInteger forMonth:monthInteger]) {
+                return NO;
             }
         }
         [formattedString appendString:dayString];
@@ -192,6 +165,42 @@
     }
     
     return NO;
+}
+
+- (BOOL)isValidDay:(NSInteger)day forMonth:(NSInteger)month {
+    
+    switch (month) {
+        case 1:
+        case 3:
+        case 5:
+        case 7:
+        case 8:
+        case 10:
+        case 12:
+            if (day < 1 || day > 31) {
+                return NO;
+            }
+            break;
+        case 4:
+        case 6:
+        case 9:
+        case 11:
+            if (day < 1 || day > 30) {
+                return NO;
+            }
+            break;
+        case 2:
+            // Month is typed before year, won't know if it's a leap year, bound check against upper limit
+            if (day < 1 || day > 29) {
+                return NO;
+            }
+            break;
+        default:
+            return NO;
+            break;
+    }
+    
+    return YES;
 }
 
 #pragma mark - Public methods

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F641EAD1ABF89C00098D2D6 /* BKBirthdayField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F641EAC1ABF89C00098D2D6 /* BKBirthdayField.m */; };
 		DF68E2D919CDE25D00EF5554 /* BKCardNumberLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = DF68E2D819CDE25D00EF5554 /* BKCardNumberLabel.m */; };
 		DFB3629A19A8F65F001E640D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFB3629919A8F65F001E640D /* Foundation.framework */; };
 		DFB3629C19A8F65F001E640D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFB3629B19A8F65F001E640D /* CoreGraphics.framework */; };
@@ -43,6 +44,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F641EAB1ABF89C00098D2D6 /* BKBirthdayField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BKBirthdayField.h; sourceTree = "<group>"; };
+		1F641EAC1ABF89C00098D2D6 /* BKBirthdayField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BKBirthdayField.m; sourceTree = "<group>"; };
 		DF68E2D719CDE25D00EF5554 /* BKCardNumberLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BKCardNumberLabel.h; sourceTree = "<group>"; };
 		DF68E2D819CDE25D00EF5554 /* BKCardNumberLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BKCardNumberLabel.m; sourceTree = "<group>"; };
 		DFB3629619A8F65F001E640D /* BKMoneyKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BKMoneyKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -105,6 +108,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F641EAA1ABF88290098D2D6 /* BirthdayField */ = {
+			isa = PBXGroup;
+			children = (
+				1F641EAB1ABF89C00098D2D6 /* BKBirthdayField.h */,
+				1F641EAC1ABF89C00098D2D6 /* BKBirthdayField.m */,
+			);
+			name = BirthdayField;
+			sourceTree = "<group>";
+		};
 		DF68E2D619CDE1ED00EF5554 /* CardNumberLabel */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				DFB362EA19A8FCD2001E640D /* Common */,
+				1F641EAA1ABF88290098D2D6 /* BirthdayField */,
 				DFB362DB19A8F7ED001E640D /* CardNumberField */,
 				DF68E2D619CDE1ED00EF5554 /* CardNumberLabel */,
 				DFB362DC19A8F80B001E640D /* CardExpiryField */,
@@ -346,6 +359,7 @@
 				DF68E2D919CDE25D00EF5554 /* BKCardNumberLabel.m in Sources */,
 				DFB362D719A8F6FB001E640D /* BKCardNumberFormatter.m in Sources */,
 				DFB362F019A8FE76001E640D /* BKForwardingTextField.m in Sources */,
+				1F641EAD1ABF89C00098D2D6 /* BKBirthdayField.m in Sources */,
 				DFB362CC19A8F6BF001E640D /* BKViewController.m in Sources */,
 				DFB362A619A8F65F001E640D /* main.m in Sources */,
 				DFB362DF19A8F823001E640D /* BKCardExpiryField.m in Sources */,

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.h
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.h
@@ -11,6 +11,7 @@
 #import "BKCardExpiryField.h"
 #import "BKCurrencyTextField.h"
 #import "BKCardNumberLabel.h"
+#import "BKBirthdayField.h"
 
 @interface BKViewController : UIViewController <UITextFieldDelegate>
 
@@ -19,9 +20,11 @@
 
 @property (weak, nonatomic) IBOutlet BKCardExpiryField *cardExpiryField;
 @property (weak, nonatomic) IBOutlet BKCurrencyTextField *currencyTextField;
+@property (weak, nonatomic) IBOutlet BKBirthdayField *birthdayField;
 
 @property (weak, nonatomic) IBOutlet UILabel *cardNumberInfoLabel;
 @property (weak, nonatomic) IBOutlet UILabel *cardExpiryLabel;
 @property (weak, nonatomic) IBOutlet UILabel *currencyTextLabel;
+@property (weak, nonatomic) IBOutlet UILabel *birthdayTextLabel;
 
 @end

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.m
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.m
@@ -35,6 +35,7 @@
     [self.cardNumberField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
     [self.cardExpiryField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
     [self.currencyTextField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
+    [self.birthdayField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
     
     [self.cardNumberField becomeFirstResponder];
     
@@ -47,6 +48,11 @@
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
+
+- (IBAction)backgroundTapped:(id)sender {
+    [[self view] endEditing:YES];
+}
+
 
 - (void)textFieldEditingChanged:(id)sender
 {
@@ -64,13 +70,28 @@
     } else if (sender == self.cardExpiryField) {
         
         NSDateComponents *dateComp = self.cardExpiryField.dateComponents;
-        self.cardExpiryLabel.text = [NSString stringWithFormat:@"month=%ld, year=%ld", dateComp.month, dateComp.year];
+        self.cardExpiryLabel.text = [NSString stringWithFormat:@"month=%ld, year=%ld", (long)dateComp.month, (long)dateComp.year];
         
     } else if (sender == self.currencyTextField) {
         
         self.currencyTextLabel.text = [NSString stringWithFormat:@"currencyCode=%@\namount=%@",
                                        self.currencyTextField.numberFormatter.currencyCode,
                                        self.currencyTextField.numberValue.description];
+    } else if (sender == self.birthdayField) {
+        
+        NSDateComponents *dateComp = self.birthdayField.dateComponents;
+        
+        // Note: ALWAYS check that date is valid before displaying, because typing in day before leap year means it is not valid
+        // Use [BKBirthdayField isLeapYear] and [BKBirthdayField isValidDate] in your custom logic to handle those cases
+        self.birthdayTextLabel.text = [NSString stringWithFormat:@"month=%ld, day=%ld, year=%ld", (long)dateComp.month, (long)dateComp.day, (long)dateComp.year];
+        
+        // For years that aren't leap years, date may be invalid if month == 2, so check && print special message
+        if (![self.birthdayField isLeapYear] && dateComp.month == 2 && dateComp.year != 0) {
+            
+            if (![self.birthdayField isValidDate]) {
+                self.birthdayTextLabel.text = @"Invalid for non-leap year";
+            }
+        }
     }
 }
 

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.xib
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.xib
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14D87h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BKViewController">
             <connections>
+                <outlet property="birthdayField" destination="XAf-cl-ViN" id="M0F-mZ-VvX"/>
+                <outlet property="birthdayTextLabel" destination="SSK-fa-MPO" id="dfY-Az-us5"/>
                 <outlet property="cardExpiryField" destination="Xi3-aO-YIu" id="Qzg-tm-SHv"/>
                 <outlet property="cardExpiryLabel" destination="jnS-Ca-1w8" id="TVR-Ag-Whk"/>
                 <outlet property="cardNumberField" destination="329-QQ-q0R" id="97r-x3-kDU"/>
@@ -34,7 +36,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="calibratedRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="j6K-56-9dT" customClass="BKCardNumberLabel">
@@ -42,7 +44,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="calibratedRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" id="Xi3-aO-YIu" customClass="BKCardExpiryField">
@@ -64,7 +66,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="calibratedRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zPo-Gy-RhH">
@@ -72,12 +74,36 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="calibratedRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" id="XAf-cl-ViN" customClass="BKBirthdayField">
+                    <rect key="frame" x="20" y="334" width="280" height="34"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="SSK-fa-MPO">
+                    <rect key="frame" x="20" y="376" width="280" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <gestureRecognizers/>
+            <connections>
+                <outletCollection property="gestureRecognizers" destination="nKH-5V-K2V" appends="YES" id="eId-U3-SDJ"/>
+            </connections>
         </view>
+        <tapGestureRecognizer id="nKH-5V-K2V">
+            <connections>
+                <action selector="backgroundTapped:" destination="-1" id="i4q-jC-Swx"/>
+            </connections>
+        </tapGestureRecognizer>
     </objects>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Card logo images by http://www.shopify.com/blog/6335014-32-free-credit-card-icon
 | ```BKCardNumberFormatter``` | Subclass of NSFormatter. This class has card number pattern information inside and formats according to patterns. You can customize masking behavior, masking character and group separater character. |
 | ```BKCardExpiryField``` | Subclass of UITextField that supports formatting card number expiry date. |
 | ```BKCurrencyTextField``` | Subclass of UITextField that supports formatting money amount. You can change currency by changing the ```currencyCode``` property of ```numberFormatter```. |
+| ```BKBirthdayField``` | Subclass of UITextField that supports formatting birthday in (MM/DD/YYYY) format. |
 
 
 ## Examples
@@ -71,3 +72,25 @@ field.numberFormatter.currencyCode = @"KRW";
 // get number value
 NSDecimalNumber *number = field.numberValue;
 ```
+
+### BKBirthdayField
+
+```objc
+BKBirthdayField *field = [[BKBirthdayField alloc] init];
+
+// validate first before accessing due to leap year logic and day being typed before year
+if ([field isValidDate]) {
+	// get day
+	NSInteger day = field.dateComponents.day;
+
+	// get month
+	NSInteger month = field.dateComponents.month;
+
+	// get year
+	NSInteger year = field.dateComponents.year;
+} else {
+	// date not valid
+}
+
+```
+


### PR DESCRIPTION
- Add finished implementation of BKBirthdayField for (MM/DD/YYYY) format
- Updated example app with BKBirthdayField and associated label
- Sample app will say "Invalid for non-leap year" if you type in month (2) and day (29) for years that are not a leap year.
- Added UITapGestureRecognizer so you can see associated label for BKBirthdayField (UIScrollView probably better, but code to account for keyboard is distracting from purpose of demo).
