### PR TITLE
Remove enforcing of Right Text Alignment

### DIFF
--- a/BKMoneyKit/BKCurrencyTextField.h
+++ b/BKMoneyKit/BKCurrencyTextField.h
@@ -10,15 +10,7 @@
 
 @interface BKCurrencyTextField : BKForwardingTextField
 
-/**
- * The currency style number formatter. 
- * You can change currency by changing currencyCode or locale property of this formatter.
- */
-@property (strong, nonatomic, readonly) NSNumberFormatter   *numberFormatter;
-
-/**
- * The decimal number that user typed.
- */
-@property (strong, nonatomic) NSDecimalNumber               *numberValue;
+@property (strong, nonatomic, readonly) NSNumberFormatter *numberFormatter;
+@property (strong, nonatomic) NSDecimalNumber *numberValue; // textField number
 
 @end

--- a/BKMoneyKit/BKCurrencyTextField.m
+++ b/BKMoneyKit/BKCurrencyTextField.m
@@ -24,7 +24,6 @@
     [super commonInit];
     
     self.keyboardType = UIKeyboardTypeNumberPad;
-    self.textAlignment = NSTextAlignmentRight;
     
     _numberFormatter = [[NSNumberFormatter alloc] init];
     _numberFormatter.numberStyle = NSNumberFormatterCurrencyStyle;


### PR DESCRIPTION
remove bit that sets the text field's alignment to always right aligned
