### PR TITLE
Fix deprecation warning

### DIFF
--- a/BKMoneyKit/BKCardExpiryField.m
+++ b/BKMoneyKit/BKCardExpiryField.m
@@ -111,7 +111,7 @@
 
 + (NSInteger)currentYear
 {
-    NSDateComponents *currentDateComponents = [[NSCalendar currentCalendar] components:NSYearCalendarUnit fromDate:[NSDate date]];
+    NSDateComponents *currentDateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitYear fromDate:[NSDate date]];
     return currentDateComponents.year;
 }
 


### PR DESCRIPTION
Replaces `NSYearCalendarUnit` with `NSCalendarUnitYear` to fix the deprecation warning under iOS 8.
