### PR TITLE
Fix for: BKCardExpiryField.m:114:88: 'NSYearCalendarUnit' is deprecated

### DIFF
--- a/BKMoneyKit/BKCardExpiryField.m
+++ b/BKMoneyKit/BKCardExpiryField.m
@@ -111,7 +111,7 @@
 
 + (NSInteger)currentYear
 {
-    NSDateComponents *currentDateComponents = [[NSCalendar currentCalendar] components:NSYearCalendarUnit fromDate:[NSDate date]];
+    NSDateComponents *currentDateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitYear fromDate:[NSDate date]];
     return currentDateComponents.year;
 }
 


### PR DESCRIPTION
Fix for: BKCardExpiryField.m:114:88: 'NSYearCalendarUnit' is deprecated: first deprecated in iOS 8.0 - Use NSCalendarUnitYear instead
