### PR TITLE
Enable up to 19-digits visa cards

### DIFF
--- a/BKMoneyKit/BKMoneyKit.bundle/CardPatterns.plist
+++ b/BKMoneyKit/BKMoneyKit.bundle/CardPatterns.plist
@@ -60,7 +60,7 @@
 		<key>numberGrouping</key>
 		<string>4,4,4,4</string>
 		<key>length</key>
-		<string>13,14,15,16</string>
+		<string>13,14,15,16,17,18,19</string>
 	</dict>
 	<dict>
 		<key>pattern</key>


### PR DESCRIPTION
According to wikipedia: https://en.wikipedia.org/wiki/Bank_card_number

> Visa's VPay brand can specify PAN lengths from 13 to 19 digits and so card numbers of more than 16 digits are now being seen.
