### PR TITLE
Import UIKit

### DIFF
--- a/BKMoneyKit/BKMoneyUtils.h
+++ b/BKMoneyKit/BKMoneyUtils.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014년 Byungkook Jang. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface BKMoneyUtils : NSObject
 


### PR DESCRIPTION
Fixes building outside of CocoaPods. UIImage header is provided by UIKit.
