### PR TITLE
Updated Visa and MasterCard number grouping

### DIFF
--- a/BKMoneyKit/BKMoneyKit.bundle/CardPatterns.plist
+++ b/BKMoneyKit/BKMoneyKit.bundle/CardPatterns.plist
@@ -58,7 +58,7 @@
 		<key>shortName</key>
 		<string>visa</string>
 		<key>numberGrouping</key>
-		<string>4,4,4,4</string>
+		<string>4,4,4,4,3</string>
 		<key>length</key>
 		<string>13,14,15,16,17,18,19</string>
 	</dict>
@@ -94,7 +94,7 @@
 		<key>shortName</key>
 		<string>maestro</string>
 		<key>numberGrouping</key>
-		<string>4,4,4,4</string>
+		<string>4,4,4,4,3</string>
 		<key>length</key>
 		<string>12,13,14,15,16,17,18,19</string>
 	</dict>


### PR DESCRIPTION
The length for cards are updated, but the textfield was still restricted to entering a maximum of 16 digits.
numberGrouping field is updated so user can enter unto 19 digits.
