### PR TITLE
Prevent adding extra space at the end for Formatter

### DIFF
--- a/BKMoneyKit/BKCardPatternInfo.m
+++ b/BKMoneyKit/BKCardPatternInfo.m
@@ -100,6 +100,10 @@
         if (substringRange.length < digitCount) {
             break;
         }
+        
+        if (aString.length == location) {
+            break;
+        }
 
         if (i < self.numberGrouping.count - 1) {
             [mutableString appendString:aGroupSeparater];


### PR DESCRIPTION
Seems there will be an extra space at the end if the text is left aligned. This commit prevents that.
