### PR TITLE
Add support for placing the Card Logo Image in the BKCardNumberField rightView.

### DIFF
--- a/BKMoneyKit/BKCardNumberField.h
+++ b/BKMoneyKit/BKCardNumberField.h
@@ -13,8 +13,21 @@
 
 /**
  * A Boolean indicating whether shows card logo left side or not.
+ * This is similar to showsCardLogoOnLeft.
  */
 @property (nonatomic) BOOL showsCardLogo;
+
+/**
+ * A Boolean indicating whether shows card logo left side or not.
+ * This is similar to showsCardLogo.
+ */
+@property (nonatomic) BOOL showsCardLogoOnLeft;
+
+/**
+ * A Boolean indicating whether shows card logo right side or not.
+ * This replaces the Clear button of the textfield.
+ */
+@property (nonatomic) BOOL showsCardLogoOnRight;
 
 /**
  * The card number without blank space. (e.g., 1234123412341234)

--- a/BKMoneyKit/BKCardNumberField.m
+++ b/BKMoneyKit/BKCardNumberField.m
@@ -9,11 +9,17 @@
 #import "BKCardNumberField.h"
 #import "BKMoneyUtils.h"
 
+typedef NS_ENUM(NSInteger, LogoImagePosition) {
+    LogoImagePositionLeft,
+    LogoImagePositionRight
+};
+
 @interface BKCardNumberField ()
 
 @property (nonatomic, strong) BKCardNumberFormatter     *cardNumberFormatter;
 @property (nonatomic, strong) UIImageView               *cardLogoImageView;
 @property (nonatomic, strong) NSCharacterSet            *numberCharacterSet;
+@property (nonatomic) LogoImagePosition                 logoImagePosition;
 
 @end
 
@@ -31,6 +37,7 @@
     
     self.keyboardType = UIKeyboardTypeNumberPad;
     self.clearButtonMode = UITextFieldViewModeAlways;
+    self.logoImagePosition = LogoImagePositionLeft;
     
     [self addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
 }
@@ -113,32 +120,57 @@
     self.cardLogoImageView.image = cardLogoImage;
 }
 
-#pragma mark - Public Methods
-
-- (void)setShowsCardLogo:(BOOL)showsCardLogo
+- (void)showCardLogoForAppliedPosition:(BOOL)showsCardLogo
 {
     if (_showsCardLogo != showsCardLogo) {
         _showsCardLogo = showsCardLogo;
-        
+
         if (showsCardLogo) {
-            
+
             CGFloat size = CGRectGetHeight(self.frame);
-            
+
             UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 44.f, size)];
             imageView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
             imageView.contentMode = UIViewContentModeCenter;
-            
-            self.leftView = imageView;
-            self.leftViewMode = UITextFieldViewModeAlways;
-            
+
+            if (self.logoImagePosition == LogoImagePositionLeft) {
+                self.leftView = imageView;
+                self.leftViewMode = UITextFieldViewModeAlways;
+            } else {
+                self.rightView = imageView;
+                self.rightViewMode = UITextFieldViewModeAlways;
+            }
+
             self.cardLogoImageView = imageView;
-            
+
             [self updateCardLogoImage];
-            
+
         } else {
             self.leftView = nil;
+            self.rightView = nil;
         }
     }
+}
+
+#pragma mark - Public Methods
+
+- (void)setShowsCardLogoOnLeft:(BOOL)showsCardLogoOnLeft
+{
+    self.logoImagePosition = LogoImagePositionLeft;
+
+    [self showCardLogoForAppliedPosition:showsCardLogoOnLeft];
+}
+
+- (void)setShowsCardLogoOnRight:(BOOL)showsCardLogoOnRight
+{
+    self.logoImagePosition = LogoImagePositionRight;
+
+    [self showCardLogoForAppliedPosition:showsCardLogoOnRight];
+}
+
+- (void)setShowsCardLogo:(BOOL)showsCardLogo
+{
+    self.showsCardLogoOnLeft = showsCardLogo;
 }
 
 - (void)setCardNumber:(NSString *)cardNumber

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.h
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.h
@@ -24,4 +24,6 @@
 @property (weak, nonatomic) IBOutlet UILabel *cardExpiryLabel;
 @property (weak, nonatomic) IBOutlet UILabel *currencyTextLabel;
 
+@property (strong, nonatomic) IBOutlet BKCardNumberField *cardNumberFieldRight;
+
 @end

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.m
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.m
@@ -28,6 +28,7 @@
     [super viewDidLoad];
 
     self.cardNumberField.showsCardLogo = YES;
+    self.cardNumberFieldRight.showsCardLogoOnRight = YES;
     
 //    self.currencyTextField.numberFormatter.currencySymbol = @"";
 //    self.currencyTextField.numberFormatter.currencyCode = @"KRW";
@@ -35,7 +36,8 @@
     [self.cardNumberField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
     [self.cardExpiryField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
     [self.currencyTextField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
-    
+    [self.cardNumberFieldRight addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
+
     [self.cardNumberField becomeFirstResponder];
     
     self.cardNumberLabel.cardNumberFormatter.maskingCharacter = @"●";       // BLACK CIRCLE        25CF
@@ -50,16 +52,24 @@
 
 - (void)textFieldEditingChanged:(id)sender
 {
-    if (sender == self.cardNumberField) {
-        
-        NSString *cardCompany = self.cardNumberField.cardCompanyName;
+    if (sender == self.cardNumberField ||
+        sender == self.cardNumberFieldRight) {
+
+        BKCardNumberField *cardNumberField = (BKCardNumberField *)sender;
+        NSString *cardCompany = cardNumberField.cardCompanyName;
         if (nil == cardCompany) {
             cardCompany = @"unknown";
         }
+
+        if (cardNumberField == self.cardNumberField) {
+            self.cardNumberFieldRight.cardNumber = cardNumberField.cardNumber;
+        } else if (cardNumberField == self.cardNumberFieldRight) {
+            self.cardNumberField.cardNumber = cardNumberField.cardNumber;
+        }
+
+        self.cardNumberLabel.cardNumber = cardNumberField.cardNumber;
         
-        self.cardNumberLabel.cardNumber = self.cardNumberField.cardNumber;
-        
-        self.cardNumberInfoLabel.text = [NSString stringWithFormat:@"company=%@\nnumber=%@", cardCompany, self.cardNumberField.cardNumber];
+        self.cardNumberInfoLabel.text = [NSString stringWithFormat:@"company=%@\nnumber=%@", cardCompany, cardNumberField.cardNumber];
         
     } else if (sender == self.cardExpiryField) {
         

--- a/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.xib
+++ b/Examples/BKMoneyKitDemo/BKMoneyKitDemo/BKViewController.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14D87h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BKViewController">
@@ -10,6 +14,7 @@
                 <outlet property="cardExpiryField" destination="Xi3-aO-YIu" id="Qzg-tm-SHv"/>
                 <outlet property="cardExpiryLabel" destination="jnS-Ca-1w8" id="TVR-Ag-Whk"/>
                 <outlet property="cardNumberField" destination="329-QQ-q0R" id="97r-x3-kDU"/>
+                <outlet property="cardNumberFieldRight" destination="zRz-2d-Qo6" id="H9Q-iL-8DX"/>
                 <outlet property="cardNumberInfoLabel" destination="Czg-id-JjF" id="tqa-of-rYb"/>
                 <outlet property="cardNumberLabel" destination="j6K-56-9dT" id="eeZ-pT-3z7"/>
                 <outlet property="currencyTextField" destination="9Xj-e1-kHD" id="tew-yz-eal"/>
@@ -19,69 +24,78 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Input card number" minimumFontSize="17" id="329-QQ-q0R" customClass="BKCardNumberField">
-                    <rect key="frame" x="20" y="40" width="280" height="34"/>
+                    <rect key="frame" x="20" y="40" width="335" height="34"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                     <textInputTraits key="textInputTraits"/>
                 </textField>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Czg-id-JjF">
-                    <rect key="frame" x="20" y="125" width="280" height="40"/>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Input card number right" minimumFontSize="17" id="zRz-2d-Qo6" customClass="BKCardNumberField">
+                    <rect key="frame" x="20" y="82" width="335" height="34"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <nil key="textColor"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="j6K-56-9dT" customClass="BKCardNumberLabel">
+                    <rect key="frame" x="20" y="124" width="280" height="35"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="calibratedRGB"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="j6K-56-9dT" customClass="BKCardNumberLabel">
-                    <rect key="frame" x="20" y="82" width="280" height="35"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" id="Xi3-aO-YIu" customClass="BKCardExpiryField">
-                    <rect key="frame" x="20" y="173" width="280" height="34"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                    <textInputTraits key="textInputTraits"/>
-                </textField>
-                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" id="9Xj-e1-kHD" customClass="BKCurrencyTextField">
-                    <rect key="frame" x="20" y="244" width="280" height="34"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                    <textInputTraits key="textInputTraits"/>
-                </textField>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jnS-Ca-1w8">
-                    <rect key="frame" x="20" y="215" width="280" height="21"/>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Czg-id-JjF">
+                    <rect key="frame" x="20" y="167" width="280" height="40"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zPo-Gy-RhH">
-                    <rect key="frame" x="20" y="286" width="280" height="40"/>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" id="Xi3-aO-YIu" customClass="BKCardExpiryField">
+                    <rect key="frame" x="20" y="215" width="335" height="34"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jnS-Ca-1w8">
+                    <rect key="frame" x="20" y="257" width="280" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" id="9Xj-e1-kHD" customClass="BKCurrencyTextField">
+                    <rect key="frame" x="20" y="286" width="335" height="34"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zPo-Gy-RhH">
+                    <rect key="frame" x="20" y="328" width="280" height="40"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.80000001192092896" green="0.80000001192092896" blue="0.80000001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <point key="canvasLocation" x="35.5" y="54.5"/>
         </view>
     </objects>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
         <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
     </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
The changes in this branch define work for allowing the placement of the Card Logo Image in the BKCardNumberField's rightView.

This does have the effect of 'replacing' the Clear button of the TextField. This can be viewed as an acceptable trade-off by users of the library.

Changes include updates to the Demo to show how this new property affects the BKCardNumberField.